### PR TITLE
fix: Fixing installation issues

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -5,11 +5,11 @@
 // Alerts
 
 .alert-dismissible .close {
-  color: theme-color("gray", "default");
+  color: theme-color("gray");
   opacity: 1;
 
   @include hover {
-    color: theme-color("gray", "hover");
+    color: theme-color("gray");
   }
 }
 

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -734,20 +734,20 @@ $form-feedback-icon-valid:          url("data:image/svg+xml,%3csvg xmlns='http:/
 $form-feedback-icon-invalid-color:  $form-feedback-invalid-color !default;
 $form-feedback-icon-invalid:        url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-feedback-icon-invalid-color}' viewBox='2 2 20 20'%3e%3cpath d='M12,2 C17.5228475,2 22,6.4771525 22,12 C22,17.5228475 17.5228475,22 12,22 C6.4771525,22 2,17.5228475 2,12 C2,6.4771525 6.4771525,2 12,2 Z M13.25,15.5 L10.75,15.5 C10.6119288,15.5 10.5,15.6119288 10.5,15.75 L10.5,15.75 L10.5,18.25 C10.5,18.3880712 10.6119288,18.5 10.75,18.5 L10.75,18.5 L13.25,18.5 C13.3880712,18.5 13.5,18.3880712 13.5,18.25 L13.5,18.25 L13.5,15.75 C13.5,15.6119288 13.3880712,15.5 13.25,15.5 L13.25,15.5 Z M13.492539,5.5 L10.5001113,5.50010806 C10.3620998,5.50416722 10.2535099,5.61933826 10.2575691,5.75734976 L10.2575691,5.75734976 L10.4928632,13.7573498 C10.4968382,13.8925005 10.607546,14 10.7427552,14 L10.7427552,14 L13.2572448,14 C13.392454,14 13.5031618,13.8925005 13.5071368,13.7573498 L13.5071368,13.7573498 L13.7424309,5.75734976 L13.7424309,5.75734976 C13.742539,5.61192881 13.6306101,5.5 13.492539,5.5 L13.492539,5.5 Z' /%3e%3c/svg%3E") !default;
 
-// $form-validation-states: () !default;
-// $form-validation-states: map-merge(
-//   (
-//     "valid": (
-//       "color": $form-feedback-valid-color,
-//       "icon": $form-feedback-icon-valid
-//     ),
-//     "invalid": (
-//       "color": $form-feedback-invalid-color,
-//       "icon": $form-feedback-icon-invalid
-//     ),
-//   ),
-//   $form-validation-states
-// );
+ $form-validation-states: () !default;
+ $form-validation-states: map-merge(
+   (
+     "valid": (
+       "color": $form-feedback-valid-color,
+       "icon": $form-feedback-icon-valid
+     ),
+     "invalid": (
+       "color": $form-feedback-invalid-color,
+       "icon": $form-feedback-icon-invalid
+     ),
+   ),
+   $form-validation-states
+ );
 
 // Z-index master list
 //


### PR DESCRIPTION
I came across issues while integrating `brand-edx.org` with edx-platfrom. 
The first issue was wrong number of arguments for the `theme-color` function. 

<img width="1187" alt="Screen Shot 2020-11-11 at 10 01 48 PM" src="https://user-images.githubusercontent.com/4252738/98841136-823af500-2469-11eb-878d-efd1ff6d66c2.png">


I resolved the issue by passing a single argument to the function call. 

Once that issue is resolved the second issue was `$form-validation-states is not defined`.

`$form-validation-states` variable is used at https://github.com/edx/brand-edx.org/blob/master/paragon/_overrides.scss#L68 but it was not initialized anywhere in `brand-edx.org`.  I observed that the variable actually exists and was commented-out in `_variables.scss` See here. https://github.com/edx/brand-edx.org/blob/master/paragon/_variables.scss#L737-L750


This might not be a perfect solution but it worked and I am happy to know if there are other (better) ways to address this.

[TNL-7669](https://openedx.atlassian.net/browse/TNL-7669)