### PR TITLE
Add missing theme-color to fix dashboard dropdown background color.

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -82,6 +82,7 @@ $danger: $red !default;
 $warning: $yellow !default;
 $light: $gray-100 !default;
 $dark: $gray-800 !default;
+$inverse: $white !default;
 
 $theme-colors: () !default;
 $theme-colors: map-merge(
@@ -94,6 +95,7 @@ $theme-colors: map-merge(
     "danger":          $danger,
     "light":           $light,
     "dark":            $dark,
+    "inverse":         $inverse
   ),
   $theme-colors
 );


### PR DESCRIPTION
This PR fixes an issue in the new brand-edx.org theme where the dashboard navigation dropdown is visually broken (background transparent).

<img width="567" alt="Screen Shot 2020-11-11 at 10 27 54 PM" src="https://user-images.githubusercontent.com/30112155/98843680-1a86a900-246d-11eb-85d3-f8960bdc0879.png">

The issue was that the `inverse` color variable was not defined in `brand-edx.org` theme and was expected by the dropdown as the background.

<img width="618" alt="Screen Shot 2020-11-11 at 10 26 43 PM" src="https://user-images.githubusercontent.com/30112155/98843660-16f32200-246d-11eb-9cc5-f2b83965ec41.png">


FYI -- @awaisdar001 