### PR TITLE
fix: remove underlines for links outside paragraphs

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -140,9 +140,27 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-p {
-  a[href]:not(.btn) {
-    text-decoration: underline;
+p > a[href]:not(.btn),
+a.inline-link {
+  text-decoration: none;
+  position: relative;
+
+  &:after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    height: 1px;
+    background: currentColor;
+    opacity: 0.3;
+  }
+
+  &:hover {
+    text-decoration: none;
+    &:after {
+      opacity: 1;
+    }
   }
 }
 

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -33,14 +33,14 @@
 
   &.hover,
   &:hover {
-    text-decoration: $link-hover-decoration;
+    text-decoration: none;
   }
 
   &.focus,
   &:focus {
     outline: 1px dotted;
     outline: 5px auto -webkit-focus-ring-color;
-    text-decoration: $link-hover-decoration;
+    text-decoration: none;
   }
 }
 

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -148,7 +148,7 @@ a.inline-link {
   &:after {
     content: "";
     position: absolute;
-    bottom: 0;
+    top: 100%;
     right: 0;
     left: 0;
     height: 1px;

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -304,9 +304,9 @@ $body-color:                $gray-700 !default;
 // Style anchor elements.
 
 $link-color:                $info !default;
-$link-decoration:           underline !default;
+$link-decoration:           none !default;
 $link-hover-color:          $info-700 !default;
-$link-hover-decoration:     underline !default;
+$link-hover-decoration:     none !default;
 // // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 // $emphasized-link-hover-darken-percentage: 15% !default;
 

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -306,7 +306,7 @@ $body-color:                $gray-700 !default;
 $link-color:                $info !default;
 $link-decoration:           none !default;
 $link-hover-color:          $info-700 !default;
-$link-hover-decoration:     none !default;
+$link-hover-decoration:     underline !default;
 // // Darken percentage for links with `.text-*` class (e.g. `.text-success`)
 // $emphasized-link-hover-darken-percentage: 15% !default;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1615421/99842803-7ffa2a00-2b3e-11eb-9a81-db0fa69b50e1.png)
Hover
![image](https://user-images.githubusercontent.com/1615421/99842828-8a1c2880-2b3e-11eb-96d3-ec66602c164d.png)
