### PR TITLE
fix: remove unused scss files

### DIFF
--- a/paragon/theme.scss
+++ b/paragon/theme.scss
@@ -1,4 +1,0 @@
-@import "~bootstrap/scss/functions";
-@import "variables";
-@import "../core/core";
-@import "overrides";

--- a/paragon/utilities-only.scss
+++ b/paragon/utilities-only.scss
@@ -1,3 +1,0 @@
-@import "~bootstrap/scss/functions";
-@import "variables";
-@import "../core/utilities-only";


### PR DESCRIPTION
These are left over from copying the original edx theme out of Paragon. The relative paths inside them wouldn't point to anything and won't compile so it's safe to assume they are unused.