### PR TITLE
fix: use text decoration for link styles

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -142,25 +142,10 @@ body {
 
 p > a[href]:not(.btn),
 a.inline-link {
-  text-decoration: none;
-  position: relative;
-
-  &:after {
-    content: "";
-    position: absolute;
-    top: 100%;
-    right: 0;
-    left: 0;
-    height: 1px;
-    background: currentColor;
-    opacity: 0.3;
-  }
-
+  text-decoration-line: underline;
+  text-decoration-color: rgba($link-color, .3);
   &:hover {
-    text-decoration: none;
-    &:after {
-      opacity: 1;
-    }
+    text-decoration-color: rgba($link-color, 1);
   }
 }
 


### PR DESCRIPTION
We have no control over the distance of the underline to the text, but we avoid problematic issues with creating underlines beneath image links:

![image](https://user-images.githubusercontent.com/1615421/100765599-ae40fa80-33c5-11eb-8ea6-103bc87c38a0.png)

Solves:
![image](https://user-images.githubusercontent.com/1615421/100765639-ba2cbc80-33c5-11eb-9ef6-4d1641c13b88.png)
