### PR TITLE
fix: deprecate edx specific color variables

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1,19 +1,3 @@
-// Brand colors
-
-$garnet: #D23228;
-$elm: #00262B;
-$limestone: #E1DDDB; // 200
-$limestone-500: #D7D3D1; // 300
-$limestone-300: #EAE6E5; // 250
-$limestone-200: #F2F0EF; // 150
-$limestone-100: #FBFAF9; // 100
-$isotope-blue: #03C7E8;
-$oxide-yellow: #F0CC00;
-$text-gray: #454545;
-$text-elm: #2D494E;
-$link-blue: #0A7DA3;
-
-
 $element-color-levels: () !default;
 $element-color-levels: map-merge(
   (
@@ -216,6 +200,23 @@ $theme-color-levels: map-merge(
   ),
   $theme-color-levels
 );
+
+
+// Brand colors. Do not use these variables (L208 - L219).
+// They are non-standard theme variables and will be removed in a future release.
+
+$garnet: $brand !default;
+$elm: $primary !default;
+$limestone: $light !default;
+$limestone-500: $light-700 !default;
+$limestone-300: $light-400 !default;
+$limestone-200: $light-300 !default;
+$limestone-100: $light-200 !default;
+$isotope-blue: $accent-a !default;
+$oxide-yellow: $accent-b !default;
+$text-gray: $gray-700 !default;
+$text-elm: $primary-300 !default;
+$link-blue: $info !default;
 
 
 // Set a specific jump point for requesting color jumps


### PR DESCRIPTION
These variables were added to this theme in error. Consuming applications should only use variable names that also exist in the Paragon core (`$primary-300`, `$light`, etc).

After we confirm that no consuming applications use these edx-specific variables, we'll delete them.