### PR TITLE
fix: darken text of default avatar button style

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -121,6 +121,11 @@
   }
 }
 
+// Avatar buttons in tertiary style (the default) are darker than regular tertiary buttons
+.btn-avatar.btn-tertiary {
+  color: $primary-500;
+}
+
 // Forms
 
 // This loop is modeled after the loop in bootstrap's _forms.scss


### PR DESCRIPTION
Theming for the new Avatar Button component https://github.com/edx/paragon/pull/593
From
![image](https://user-images.githubusercontent.com/1615421/101668737-e9bf7280-3a1e-11eb-818e-5cd859124681.png)

To
![image](https://user-images.githubusercontent.com/1615421/101661749-aa8d2380-3a16-11eb-994e-d1e02d0c4b4c.png)
