### PR TITLE
fix: darken blue for color contrast

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -25,7 +25,7 @@ $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
 $black:    #000 !default;
 
-$blue:    #0A7DA3 !default;
+$blue:    #00688D !default;
 // $indigo:  #6610f2 !default;
 // $purple:  #6f42c1 !default;
 // $pink:    #d63384 !default;


### PR DESCRIPTION
Darken info blue so that it maintains 4.5:1 contrast on all 100 level utility colors and light 500 - 100.

![image](https://user-images.githubusercontent.com/1615421/101839246-07203980-3b10-11eb-8fbe-03cfc16ee128.png)
