### PR TITLE
[BD-35] PAR-287 feat: change styles according to new badge component design

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -17,8 +17,8 @@
 // Badges
 
 .badge {
-  font-family: $font-family-monospace;
-  text-transform: uppercase;
+  font-family: $font-family-sans-serif;
+  line-height: 1.25rem;
 }
 
 

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -76,8 +76,8 @@ $theme-colors: map-merge(
     "primary":         $primary,
     "brand":           $brand,
     "success":         $success,
-    "info":            $info,
-    "warning":         $warning,
+    "info":            $accent-a,
+    "warning":         $accent-b,
     "danger":          $danger,
     "light":           $light,
     "dark":            $dark,
@@ -1082,9 +1082,9 @@ $toast-box-shadow:                  $level-4-box-shadow !default;
 
 $badge-font-size:                   0.75rem !default;
 $badge-font-weight:                 400 !default;
-$badge-padding-y:                   .25rem !default;
-$badge-padding-x:                   .75rem !default;
-$badge-border-radius:               10rem !default;
+// $badge-padding-y:                   .125rem !default;
+// $badge-padding-x:                   .5rem !default;
+// $badge-border-radius:               .25rem !default;
 
 // $badge-transition:                  $btn-transition !default;
 // $badge-focus-width:                 $input-btn-focus-width !default;


### PR DESCRIPTION
@abutterworth 
Ticket on Jira: https://openedx.atlassian.net/browse/PAR-287
Update badge component according to the new design: https://www.figma.com/file/eGmDp94FlqEr4iSqy1Uc1K/Paragon-2021?node-id=6703%3A52
![badge-old](https://user-images.githubusercontent.com/36944773/109713170-e267bb00-7b6e-11eb-84b7-96ab120169ef.jpg)
![badge-new](https://user-images.githubusercontent.com/36944773/109713172-e398e800-7b6e-11eb-906d-df7de0b51fed.jpg)
 