### PR TITLE
[BD-35] PAR-282 fix: change default color to primary in tooltip variables

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1013,7 +1013,7 @@ $card-spacer-x:                     1.5rem !default;
 // $tooltip-font-size:                 $font-size-sm !default;
 // $tooltip-max-width:                 200px !default;
 // $tooltip-color:                     $white !default;
-// $tooltip-bg:                        $black !default;
+$tooltip-bg:                        $primary !default;
 // $tooltip-border-radius:             $border-radius !default;
 // $tooltip-opacity:                   .9 !default;
 // $tooltip-padding-y:                 .25rem !default;
@@ -1023,6 +1023,10 @@ $card-spacer-x:                     1.5rem !default;
 // $tooltip-arrow-width:               .8rem !default;
 // $tooltip-arrow-height:              .4rem !default;
 // $tooltip-arrow-color:               $tooltip-bg !default;
+
+$tooltip-color-light:               $primary !default;;
+// $tooltip-bg-light:                  $white !default;
+// $tooltip-arrow-color-light:         $white !default;
 
 // Form tooltips must come after regular tooltips
 // $form-feedback-tooltip-padding-y:     $tooltip-padding-y !default;


### PR DESCRIPTION
@abutterworth 
Change default color on tooltip component according to new design
![old-design-edx-tool](https://user-images.githubusercontent.com/36944773/111229902-bdcf0280-85b4-11eb-91fb-dc9bd67f8007.jpg)
![new-design-edx-tool](https://user-images.githubusercontent.com/36944773/111229903-be679900-85b4-11eb-8a48-c024f663d462.jpg)
