### PR TITLE
fix: update to primary and gray color ramps and container max width

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -196,7 +196,6 @@ select.form-control {
 }
 
 .container-fluid {
-  max-width: 1140px + 2 * $grid-gutter-width;
   padding-left: $grid-gutter-width;
   padding-right: $grid-gutter-width;
 }

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -14,14 +14,14 @@ $element-color-levels: map-merge(
 // Color system
 
 $white:    #fff !default;
-$gray-100: #f8f9fa !default;
-$gray-200: #e9ecef !default;
-$gray-300: #dee2e6 !default;
-$gray-400: #ced4da !default;
+$gray-100: #ebebeb !default;
+$gray-200: #cccccc !default;
+$gray-300: #adadad !default;
+$gray-400: #8f8f8f !default;
 $gray-500: #707070 !default;
-$gray-600: #6c757d !default;
+$gray-600: #5c5c5c !default;
 $gray-700: #454545 !default;
-$gray-800: #343a40 !default;
+$gray-800: #333333 !default;
 $gray-900: #212529 !default;
 $black:    #000 !default;
 
@@ -93,7 +93,9 @@ $theme-colors: map-merge(
 
 
 $primary-300: #2D494E;
+$primary-400: #0E3639;
 $primary-500: $primary;
+$primary-600: #002326;
 $primary-700: #002121;
 
 $brand-500: $brand;
@@ -109,6 +111,7 @@ $dark-200: #475B65;
 $dark-300: #2D494E;
 $dark-400: #0E3639;
 $dark-500: $dark;
+$dark-600: #002326;
 $dark-700: #002121;
 
 $info-100: #EFF8FA;

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -741,8 +741,8 @@ $input-focus-box-shadow:                $input-btn-focus-box-shadow !default;
 // $custom-select-bg:                  $input-bg !default;
 // $custom-select-disabled-bg:         $gray-200 !default;
 // $custom-select-bg-size:             8px 10px !default; // In pixels because image dimensions
-$custom-select-indicator-color:     $primary !default;
-$custom-select-indicator:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'><path fill='#{$custom-select-indicator-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/></svg>") !default;
+// $custom-select-indicator-color:     $primary !default;
+// $custom-select-indicator:           url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'><path fill='#{$custom-select-indicator-color}' d='M2 0L0 2h4zm0 5L0 3h4z'/></svg>") !default;
 // $custom-select-background:          escape-svg($custom-select-indicator) no-repeat right $custom-select-padding-x center / $custom-select-bg-size !default; // Used so we can have multiple background elements (e.g., arrow and feedback icon)
 
 // $custom-select-feedback-icon-padding-right: add(1em * .75, (2 * $custom-select-padding-y * .75) + $custom-select-padding-x + $custom-select-indicator-padding) !default;

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -633,7 +633,7 @@ $btn-focus-width: 2px;
 // $input-font-size-lg:                    $input-btn-font-size-lg !default;
 // $input-line-height-lg:                  $input-btn-line-height-lg !default;
 
-$input-bg:                              $light-200 !default;
+$input-bg:                              $white !default;
 // $input-disabled-bg:                     $gray-200 !default;
 
 $input-color:                           $body-color !default;


### PR DESCRIPTION
Minor updates to fix bumps in the existing color ramp and prevent grays from being too light:

![image](https://user-images.githubusercontent.com/1615421/111525853-69529100-8734-11eb-945b-dbf3e70e0971.png)

now:

![image](https://user-images.githubusercontent.com/1615421/111525975-88e9b980-8734-11eb-8648-dadb05fe21c2.png)

Also includes a change to select indicators (since the appropriate style is being defined in Paragon itself) and the default input background.