### PR TITLE
feat: add theme js

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,17 @@ Use the theme in this package as described in the Paragon docs: https://edx.gith
   @import "@edx/paragon/scss/core/core";
   @import "@edx/brand/paragon/overrides";
 
+Paragon also requires a CSS-in-JS theme.
+
+.. code-block:: javascript
+
+  import theme from '@edx/brand/paragon/theme';
+
+  ReactDOM.render(
+    <ParagonProvider theme={theme} locale="en-us">
+      ...
+    </ParagonProvider>
+  );
 
 --------------------------------
 Publishing with Semantic Release

--- a/paragon/theme.js
+++ b/paragon/theme.js
@@ -1,0 +1,10 @@
+// The theme.js for Paragon. The structure of this object follows the
+// theme specification found here: https://system-ui.com/theme/. Theme values
+// not defined here will fallback to their Paragon defaults.
+
+const theme = {
+
+};
+
+export default theme;
+


### PR DESCRIPTION
Add support for CSS-in-JS theming new to Paragon: https://github.com/edx/paragon/pull/702