### PR TITLE
fix: update use of division operator to fix for sass breaking change

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -208,47 +208,47 @@ body {
 }
 
 h1, .h1 {
-  line-height: (44/16) * 1rem;
+  line-height: calc(44 / 16) * 1rem;
   letter-spacing: -2%;
 
   @media (max-width: map-get($grid-breakpoints, "sm")) {
-    line-height: (40/16) * 1rem;
+    line-height: calc(40 / 16) * 1rem;
   }
   .mobile-type & {
-    line-height: (40/16) * 1rem;
+    line-height: calc(40 / 16) * 1rem;
   }
 }
 
 h2, .h2 {
-  line-height: (36/16) * 1rem;
+  line-height: calc(36 / 16) * 1rem;
 }
 
 h3, .h3 {
-  line-height: (28/16) * 1rem;
+  line-height: calc(28 / 16) * 1rem;
 }
 
 h4, .h4 {
-  line-height: (24/16) * 1rem;
+  line-height: calc(24 / 16) * 1rem;
 }
 
 h5, .h5 {
-  line-height: (20/16) * 1rem;
+  line-height: calc(20 / 16) * 1rem;
 }
 
 h6, .h6 {
-  line-height: (20/16) * 1rem;
+  line-height: calc(20 / 16) * 1rem;
 }
 
 .lead {
-  line-height: (36/16) * 1rem;
+  line-height: calc(36 / 16) * 1rem;
 }
 
 .small {
-  line-height: (24/16) * 1rem;
+  line-height: calc(24 / 16) * 1rem;
 }
 
 .x-small {
-  line-height: (20/16) * 1rem;
+  line-height: calc(20 / 16) * 1rem;
 }
 
 p > a[href]:not(.btn),


### PR DESCRIPTION
Update the division operator so we can use these files with sass >= 1.33.0 https://sass-lang.com/documentation/breaking-changes/slash-div