### PR TITLE
fix: include multiplication in calc function

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -208,47 +208,47 @@ body {
 }
 
 h1, .h1 {
-  line-height: calc(44 / 16) * 1rem;
+  line-height: calc((44 / 16) * 1rem);
   letter-spacing: -2%;
 
   @media (max-width: map-get($grid-breakpoints, "sm")) {
-    line-height: calc(40 / 16) * 1rem;
+    line-height: calc((40 / 16) * 1rem);
   }
   .mobile-type & {
-    line-height: calc(40 / 16) * 1rem;
+    line-height: calc((40 / 16) * 1rem);
   }
 }
 
 h2, .h2 {
-  line-height: calc(36 / 16) * 1rem;
+  line-height: calc((36 / 16) * 1rem);
 }
 
 h3, .h3 {
-  line-height: calc(28 / 16) * 1rem;
+  line-height: calc((28 / 16) * 1rem);
 }
 
 h4, .h4 {
-  line-height: calc(24 / 16) * 1rem;
+  line-height: calc((24 / 16) * 1rem);
 }
 
 h5, .h5 {
-  line-height: calc(20 / 16) * 1rem;
+  line-height: calc((20 / 16) * 1rem);
 }
 
 h6, .h6 {
-  line-height: calc(20 / 16) * 1rem;
+  line-height: calc((20 / 16) * 1rem);
 }
 
 .lead {
-  line-height: calc(36 / 16) * 1rem;
+  line-height: calc((36 / 16) * 1rem);
 }
 
 .small {
-  line-height: calc(24 / 16) * 1rem;
+  line-height: calc((24 / 16) * 1rem);
 }
 
 .x-small {
-  line-height: calc(20 / 16) * 1rem;
+  line-height: calc((20 / 16) * 1rem);
 }
 
 p > a[href]:not(.btn),


### PR DESCRIPTION
The previous PR #39 caused some sandbox builds to break, for example [this one](https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/45920/console) on frontend-app-authn. In that PR we changed some implicit division calculations to be wrapped with `calc`. However we only wrapped the division operator and not the multiplication. This worked fine on later versions of sass starting at `1.40.1` (see [changelog](https://github.com/sass/dart-sass/blob/main/CHANGELOG.md#1401)), but `frontend-app-authn` used `1.26.11` which did not handle multiplication of a `calc` function with another number. The error was: `SassError: Undefined operation "calc(44 / 16) * 1rem".`

This PR moves the multiplications inside the calc function so that dart-sass can handle them appropriately, for `1.26.11` and later versions as well.