### PR TITLE
[BD-46] fix: use pixel values for button border-radius variable

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -603,9 +603,9 @@ $btn-inverse-tertiary-active-bg:      $primary-300 !default;
 // $btn-block-spacing-y:         .5rem !default;
 
 // Allows for customizing button radius independently from global border radius
-$btn-border-radius:           0 !default;
-$btn-border-radius-lg:        0 !default;
-$btn-border-radius-sm:        0 !default;
+$btn-border-radius:           0px !default;
+$btn-border-radius-lg:        0px !default;
+$btn-border-radius-sm:        0px !default;
 
 // $btn-transition:              color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out !default;
 


### PR DESCRIPTION
Explicitly specify pixel values for `Button` border-radius variable since this values is used in `calc` method and leaving it as just `0` led to incorrect border-radius being applied in Paragon (`calc` doesn't know how to work with zeros), see [PAR-764](https://openedx.atlassian.net/browse/PAR-764) for reference
