### PR TITLE
[BD-46]:  style names were updated

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -379,10 +379,10 @@ $border-radius-sm:            .375rem !default;
 
 // Elevation
 
-$level-1-box-shadow: 0px 2px 8px 0px rgba(0,0,0,0.15), 0px 2px 4px 0px rgba(0,0,0,0.15);
-$level-2-box-shadow: 0px 4px 10px 0px rgba(0,0,0,0.15), 0px 8px 16px 0px rgba(0,0,0,0.15);
-$level-3-box-shadow: 0px 8px 20px 0px rgba(0,0,0,0.15), 0px 10px 20px 0px rgba(0,0,0,0.15);
-$level-4-box-shadow: 0px 8px 48px 0px rgba(0,0,0,0.15), 0px 20px 40px 0px rgba(0,0,0,0.15);
+$box-shadow-down-1:  0px 2px 8px 0px rgba(0,0,0,0.15), 0px 2px 4px 0px rgba(0,0,0,0.15);
+$box-shadow-down-2:  0px 4px 10px 0px rgba(0,0,0,0.15), 0px 8px 16px 0px rgba(0,0,0,0.15);
+$box-shadow-down-3:  0px 8px 20px 0px rgba(0,0,0,0.15), 0px 10px 20px 0px rgba(0,0,0,0.15);
+$box-shadow-down-4:  0px 8px 48px 0px rgba(0,0,0,0.15), 0px 20px 40px 0px rgba(0,0,0,0.15);
 
 
 $box-shadow-sm:               $level-1-box-shadow !default;


### PR DESCRIPTION
As a result of [OeX_Paragon-628](https://youtrack.raccoongang.com/issue/OeX_Paragon-628)
`$level-{level}-box-shadow` scss variables have been reamed to `$box-shadow-down-{level}`, these changes need to reflected i edx.org theme repository

**AC**
- in [edx.org theme repo](https://github.com/edx/brand-edx.org/blob/master/paragon/_variables.scss#L382) rename `$level-{level}-box-shadow` scss variables have toto `$box-shadow-down-{level}`

