### PR TITLE
chore: add alpha to release.yml branches.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - alpha
 jobs:
   release:
     name: Release


### PR DESCRIPTION
Enables the release.yml Github Action workflow to run for `alpha` branch. This will be needed to trigger an `alpha` release to NPM from the `alpha` branch.