### PR TITLE
feat: added grid-gutter-width token

### DIFF
--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -346,7 +346,7 @@ $link-hover-decoration: var(--pgn-typography-link-decoration-hover) !default;
 // Set the number of columns and specify the width of the gutters.
 
 // $grid-columns:                12 !default;
-$grid-gutter-width:           32px !default;
+$grid-gutter-width: var(--pgn-spacing-grid-gutter-width) !default;
 // $grid-row-columns:            6 !default;
 
 

--- a/paragon/css/core/variables.css
+++ b/paragon/css/core/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Sun, 04 Jun 2023 20:23:54 GMT
+ * Generated on Thu, 15 Jun 2023 15:32:46 GMT
  */
 
 :root {
@@ -19,6 +19,7 @@
   --pgn-typography-btn-font-weight: 500;
   --pgn-typography-badge-font-weight: 400;
   --pgn-typography-badge-font-size: 0.75rem;
+  --pgn-spacing-grid-gutter-width: 32px;
   --pgn-spacing-dropdown-padding-y-item: .625rem;
   --pgn-spacing-dropdown-padding-y-base: .5rem;
   --pgn-spacing-card-spacer-y: 1rem;

--- a/tokens/src/core/global/spacing.json
+++ b/tokens/src/core/global/spacing.json
@@ -1,0 +1,7 @@
+{
+  "spacing": {
+    "grid": {
+      "gutter-width": { "value": "32px" }
+    }
+  }
+}


### PR DESCRIPTION
Issue: https://github.com/openedx/paragon/issues/2356

- Ensure $grid-gutter-width has a design token and associated CSS variable.
- Use above CSS variable in _overrides.scss and in core.scss with @edx/brand-edx.org