### PR TITLE
chore: experiment with not including font @import in CSS, but rather via `<link>` in HTML

### DIFF
--- a/paragon/css/core/index.css
+++ b/paragon/css/core/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono&display=swap');
+/* @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono&display=swap'); */
 
 @import "./variables.css";
 @import "./custom-media-breakpoints.css";


### PR DESCRIPTION
When `core.css` or `core.min.css` loads in the browser, the stylesheet's loading gets render-blocked by a CSS `@import` for the `Inter` Google Font:

```css
@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono&display=swap');
```

This `@import` means that users must first download the `core.min.css`, parse it, and then perform the dynamic `@import` for the `Inter` font:

<img width="459" alt="image" src="https://github.com/edx/brand-edx.org/assets/2828721/9eb39beb-ec11-445e-8d71-0c18dbf60d7c">

This PR releases a version of `alpha` that does not include the dynamic `@import` to rely instead of a `<link rel="preload" as="font">` instead to see any performance differences in render-blocking content. 