### PR TITLE
[BD-46] fix: do not override `SearchField` styles

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -364,22 +364,6 @@ a.inline-link {
   }
 }
 
-// Temporary fix for search fields. See https://github.com/edx/brand-edx.org/pull/9#issuecomment-723208124
-
-.pgn__searchfield {
-  border-radius: 0 !important;
-  .btn {
-    background: $input-bg;
-    display: flex;
-  }
-  &.has-focus {
-    .btn {
-      background: $input-focus-bg;
-    }
-    border-color: $input-focus-border-color !important;
-  }
-}
-
 // Progress Bar
 .progress {
   border: $progress-bar-border-width solid $progress-bar-border-color;


### PR DESCRIPTION
This PR together with https://github.com/openedx/paragon/pull/2675 fix https://github.com/openedx/paragon/issues/2650 by removing old and unnecessarry overrides of `SearchField` component. This way `SearchField` will inherit button styles from Paragon's `Button` component which will solve design issues with the component.

**Note** that consuming MFEs will need to upgrade versions of brand-edx.org package and Paragon together in one commit in order for the fix to work.