### PR TITLE
[BD-46] fix: fixed Popover arrow

### DIFF
--- a/paragon/css/core/index.css
+++ b/paragon/css/core/index.css
@@ -1,4 +1,4 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Roboto+Mono&display=swap');
 
-@import "./custom-media-breakpoints.css";
-@import "./variables.css";
+@import "custom-media-breakpoints.css";
+@import "variables.css";

--- a/paragon/css/core/variables.css
+++ b/paragon/css/core/variables.css
@@ -1,7 +1,7 @@
 /**
  * IMPORTANT: This file is the result of assembling design tokens
  * Do not edit directly
- * Generated on Sun, 23 Jul 2023 16:09:04 GMT
+ * Generated on Mon, 27 Nov 2023 16:19:13 GMT
  */
 
 :root {
@@ -25,7 +25,7 @@
   --pgn-spacing-card-spacer-y: 1rem;
   --pgn-spacing-card-spacer-x: 1.5rem;
   --pgn-spacing-btn-focus-gap: 2px;
-  --pgn-size-popover-border-width: 0;
+  --pgn-size-popover-border-width: 0px;
   --pgn-size-nav-pills-border-radius: 0;
   --pgn-size-image-thumbnail-border-radius: 0;
   --pgn-size-input-btn-border-width: 1px;

--- a/tokens/src/core/components/Popover.json
+++ b/tokens/src/core/components/Popover.json
@@ -2,7 +2,7 @@
   "size": {
     "popover": {
       "border": {
-        "width": { "value": "0" }
+        "width": { "value": "0px", "_comment": "A pixel next to zero is necessary for correct display Popover arrow." }
       }
     }
   }


### PR DESCRIPTION
Missing arrow in Popover component (only Brand-Edx.org theme)

**Issue:** https://github.com/openedx/paragon/issues/2799