### PR TITLE
fix: removed the studio help button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-  "name": "@edx/brand-edx.org",
+  "name": "@mitol/brand-mitxonline",
   "version": "1.0.0",
-  "description": "A package containing brand elements and SASS themes for edx.org",
+  "description": "A package containing brand elements and SASS themes for MITxOnline",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/edx/brand-edx.org.git"
+    "url": "git+https://github.com/mitodl/brand-mitxonline.git"
   },
-  "author": "edX",
-  "license": "UNLICENSED",
+  "author": "MIT",
+  "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/edx/brand-edx.org/issues"
+    "url": "https://github.com/mitodl/brand-mitxonline/issues"
   },
-  "homepage": "https://github.com/edx/brand-edx.org#readme",
+  "homepage": "https://github.com/mitodl/brand-mitonline#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -394,3 +394,11 @@ a.inline-link {
     color: $gray-900;
   }
 }
+
+div:has(> [data-testid="helpToggleButton"]) {
+  display: none;
+}
+
+.help-sidebar-about{
+  display: none;
+}


### PR DESCRIPTION
## What are the relevant tickets
https://github.com/mitodl/hq/issues/3482

## Description (What does it do?)
- Removes the 'Looking for help with studio' button
- Removes the sidebar help message
- Updates the config for our npm package details

## Screenshots
### Before
<img width="1440" alt="Screenshot 2024-03-26 at 6 22 33 PM" src="https://github.com/edx/brand-edx.org/assets/88967643/eebe7354-dba0-465b-8f62-638483354267">

### After
<img width="1440" alt="Screenshot 2024-03-26 at 6 24 55 PM" src="https://github.com/edx/brand-edx.org/assets/88967643/ea5724f5-fe6a-427d-99d7-115455cde081">

## How can this be manually tested?
- Setup [course-authoring](https://github.com/openedx/frontend-app-course-authoring) MFE locally.
- Go to localhost:2001/home and after login, notice the presence of Help button in the bottom and the sidebar message.
- In your MFE folder clone this branch
- Create a `module.config.js` file if it dost not exist already and add the following lines in it:
```
    module.exports = {
      localModules: [
        { moduleName: '@edx/brand', dir: './brand-mitxonline'},        
    ]
}
```
- Restart your MFE and validate the changes