### PR TITLE
Use semantic release version compatible with node 18.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,4 +23,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
-        run: npx semantic-release
+        run: npx semantic-release@22


### PR DESCRIPTION
semantic-release [version 23](https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0) drops support for node 18 and requires a minimum of 20.8.1.

This commit pins the version of semantic-release in the release workflow to [version 22](https://github.com/semantic-release/semantic-release/releases/tag/v22.0.0) until the platform upgrades to node 20 from node 18.